### PR TITLE
feat generate authorization url by provider

### DIFF
--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/config/ApiException.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/config/ApiException.java
@@ -1,0 +1,13 @@
+package br.com.nicolastessuto.auth_integration_api.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class ApiException {
+    private String message;
+    private LocalDateTime date;
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/config/ApiExceptionHandler.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/config/ApiExceptionHandler.java
@@ -1,0 +1,45 @@
+package br.com.nicolastessuto.auth_integration_api.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+@Slf4j
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiException> handleUnexpectedExceptions(Exception ex) {
+        log.error("Internal server error:", ex);
+        return ResponseEntity.badRequest().body(new ApiException("Oops! Something went wrong...", LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiException> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(new ApiException(ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiException> handleNoResourceFoundException(NoResourceFoundException ex) {
+        return ResponseEntity.badRequest().body(new ApiException(ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiException> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
+        return ResponseEntity.badRequest().body(new ApiException(ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiException> handleMissingParams(MissingServletRequestParameterException ex) {
+        String name = ex.getParameterName();
+        String message = "The required parameter '" + name + "' is missing.";
+        return ResponseEntity.badRequest().body(new ApiException(message, LocalDateTime.now()));
+    }
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/auth/Provider.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/auth/Provider.java
@@ -1,0 +1,8 @@
+package br.com.nicolastessuto.auth_integration_api.domain.auth;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Provider {
+    HUBSPOT
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/rest/AuthController.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/rest/AuthController.java
@@ -1,0 +1,30 @@
+package br.com.nicolastessuto.auth_integration_api.domain.rest;
+
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.AuthService;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.response.AuthLinkResponse;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.response.AvailableProvidersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/available-providers")
+    public ResponseEntity<AvailableProvidersResponse> getAvailableProvidersResponse() {
+        return ResponseEntity.ok(authService.getAvailableProviders());
+    }
+
+    @GetMapping("/login-url")
+    public ResponseEntity<AuthLinkResponse> getAuthLink(@RequestParam String provider) {
+        return ResponseEntity.ok(authService.getAuthLink(provider));
+    }
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/AuthFactory.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/AuthFactory.java
@@ -1,0 +1,23 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth;
+
+import br.com.nicolastessuto.auth_integration_api.domain.auth.Provider;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.client.HubspotAuthClient;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthFactory {
+
+    private static ApplicationContext context;
+
+    public AuthFactory(ApplicationContext context) {
+        AuthFactory.context = context;
+    }
+
+    public static GenericAuthClient getAuthServiceProvider(Provider provider) {
+        return switch (provider) {
+            case HUBSPOT -> context.getBean(HubspotAuthClient.class);
+        };
+    }
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/AuthService.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/AuthService.java
@@ -1,0 +1,11 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth;
+
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.response.AuthLinkResponse;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.response.AvailableProvidersResponse;
+
+public interface AuthService {
+    AuthLinkResponse getAuthLink(String providerRequest);
+
+    AvailableProvidersResponse getAvailableProviders();
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/GenericAuthClient.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/GenericAuthClient.java
@@ -1,0 +1,5 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth;
+
+public interface GenericAuthClient {
+    String getAuthLink();
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/client/HubspotAuthClient.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/client/HubspotAuthClient.java
@@ -1,0 +1,31 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth.client;
+
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.GenericAuthClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HubspotAuthClient implements GenericAuthClient {
+
+    @Value("${authentication-provider.hubspot.application.id}")
+    private String HUBSPOT_APPLICATION_ID;
+
+    @Value("${authentication-provider.hubspot.application.client-id}")
+    private String HUBSPOT_CLIENT_ID;
+
+    @Value("${authentication-provider.hubspot.application.client-secret}")
+    private String HUBSPOT_CLIENT_SECRET;
+
+    @Value("${authentication-provider.hubspot.application.redirect-uri}")
+    private String HUBSPOT_REDIRECT_URI;
+
+    private String HUBSPOT_AUTH_BASE_LINK =
+            "https://app.hubspot.com/oauth/authorize?" +
+                    "client_id=%s&scope=oauth&redirect_uri=%s";
+
+    @Override
+    public String getAuthLink() {
+        return String.format(String.format(HUBSPOT_AUTH_BASE_LINK, HUBSPOT_CLIENT_ID, HUBSPOT_REDIRECT_URI));
+    }
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/impl/AuthServiceImpl.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/impl/AuthServiceImpl.java
@@ -31,7 +31,7 @@ public class AuthServiceImpl implements AuthService {
         try {
             return Provider.valueOf(providerRequest.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Provider não suportado");
+            throw new IllegalArgumentException("Provider not supported");
         }
     }
 

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/impl/AuthServiceImpl.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/impl/AuthServiceImpl.java
@@ -1,0 +1,50 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth.impl;
+
+import br.com.nicolastessuto.auth_integration_api.domain.auth.Provider;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.AuthFactory;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.AuthService;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.GenericAuthClient;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.response.AuthLinkResponse;
+import br.com.nicolastessuto.auth_integration_api.domain.service.auth.response.AvailableProvidersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    @Override
+    public AuthLinkResponse getAuthLink(String providerRequest) {
+        Provider provider = validateAndGetProvider(providerRequest);
+
+        GenericAuthClient genericAuthClient = AuthFactory.getAuthServiceProvider(provider);
+
+        return AuthLinkResponse.builder()
+                .link(genericAuthClient.getAuthLink())
+                .build();
+    }
+
+    private Provider validateAndGetProvider(String providerRequest) {
+        try {
+            return Provider.valueOf(providerRequest.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Provider não suportado");
+        }
+    }
+
+    @Override
+    public AvailableProvidersResponse getAvailableProviders() {
+        List<String> providers = new ArrayList<>();
+
+        for (Provider provider : Provider.values()){
+            providers.add(provider.name());
+        }
+        return AvailableProvidersResponse.builder()
+                .providers(providers)
+                .build();
+    }
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/response/AuthLinkResponse.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/response/AuthLinkResponse.java
@@ -1,0 +1,8 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth.response;
+
+import lombok.Builder;
+
+@Builder
+public record AuthLinkResponse(String link) {
+
+}

--- a/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/response/AvailableProvidersResponse.java
+++ b/src/main/java/br/com/nicolastessuto/auth_integration_api/domain/service/auth/response/AvailableProvidersResponse.java
@@ -1,0 +1,14 @@
+package br.com.nicolastessuto.auth_integration_api.domain.service.auth.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class AvailableProvidersResponse {
+
+    private List<String> providers;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,11 @@
 spring:
   application:
     name: auth-integration-api
+
+authentication-provider:
+  hubspot:
+    application:
+      id: ${HUBSPOT_APPLICATION_ID}
+      client-id: ${HUBSPOT_CLIENT_ID}
+      client-secret: ${HUBSPOT_CLIENT_SECRET}
+      redirect-uri: ${HUBSPOT_REDIRECT_URI}


### PR DESCRIPTION
## New feature!

- Now users can generate the login URL by using the endpoint '/api/v1/auth/login-url' choosing between authorization providers 
> Required parameter 'provider'

- They can also list available providers using the endpoint '/api/v1/auth/available-providers'